### PR TITLE
[Bug] Array - 1l & 0l use static_cast<zend_long>

### DIFF
--- a/phpcxx/array.cpp
+++ b/phpcxx/array.cpp
@@ -103,8 +103,8 @@ phpcxx::Value& phpcxx::Array::operator[](const Value& key)
             case Type::String:    return this->operator[](Z_STR(key.m_z));
             case Type::Integer:   return this->operator[](Z_LVAL(this->m_z));
             case Type::Double:    return this->operator[](zend_dval_to_lval(Z_DVAL(this->m_z)));
-            case Type::True:      return this->operator[](1l);
-            case Type::False:     return this->operator[](0l);
+            case Type::True:      return this->operator[](static_cast<zend_long>(1l));
+            case Type::False:     return this->operator[](static_cast<zend_long>(0l));
             case Type::Resource:  return this->operator[](Z_RES_HANDLE_P(z));
             case Type::Undefined: return this->operator[](ZSTR_EMPTY_ALLOC());
             case Type::Null:      return this->operator[](ZSTR_EMPTY_ALLOC());
@@ -165,8 +165,8 @@ bool phpcxx::Array::contains(const Value& key) const
             case Type::String:    return this->contains(Z_STR(key.m_z));
             case Type::Integer:   return this->contains(Z_LVAL(this->m_z));
             case Type::Double:    return this->contains(zend_dval_to_lval(Z_DVAL(this->m_z)));
-            case Type::True:      return this->contains(1l);
-            case Type::False:     return this->contains(0l);
+            case Type::True:      return this->contains(static_cast<zend_long>(1l));
+            case Type::False:     return this->contains(static_cast<zend_long>(0l));
             case Type::Resource:  return this->contains(Z_RES_HANDLE_P(z));
             case Type::Undefined: return this->contains(ZSTR_EMPTY_ALLOC());
             case Type::Null:      return this->contains(ZSTR_EMPTY_ALLOC());
@@ -207,8 +207,8 @@ void phpcxx::Array::unset(const Value& key)
             case Type::String:    return this->unset(Z_STR(key.m_z));
             case Type::Integer:   return this->unset(Z_LVAL(this->m_z));
             case Type::Double:    return this->unset(zend_dval_to_lval(Z_DVAL(this->m_z)));
-            case Type::True:      return this->unset(1l);
-            case Type::False:     return this->unset(0l);
+            case Type::True:      return this->unset(static_cast<zend_long>(1l));
+            case Type::False:     return this->unset(static_cast<zend_long>(0l));
             case Type::Resource:  return this->unset(Z_RES_HANDLE_P(z));
             case Type::Undefined: return this->unset(ZSTR_EMPTY_ALLOC());
             case Type::Null:      return this->unset(ZSTR_EMPTY_ALLOC());


### PR DESCRIPTION
Hey!

### Attention: That I cannot compile because a lot of issues

Problem is similar for this 3 cases

![image](https://cloud.githubusercontent.com/assets/572096/24070087/7ef1f5d8-0bf9-11e7-8b1f-43b93147f3bf.png)

as text

```
phpcxx/array.cpp:169:48: error: call to member function 'contains' is ambiguous
            case Type::False:     return this->contains(0l);
                                         ~~~~~~^~~~~~~~
phpcxx/array.h:50:27: note: candidate function
    [[gnu::nonnull]] bool contains(zend_string* key) const;
                          ^
phpcxx/array.h:60:10: note: candidate function
    bool contains(const char* key) const;
         ^
phpcxx/array.cpp:153:21: note: candidate function
bool phpcxx::Array::contains(zend_long idx) const
                    ^
phpcxx/array.h:61:10: note: candidate function
    bool contains(const string& key) const;
         ^
phpcxx/array.h:62:10: note: candidate function
    bool contains(const ZendString& key) const;
         ^
phpcxx/array.cpp:159:21: note: candidate function
bool phpcxx::Array::contains(const Value& key) const
```

Maybe we should help Language to this case

![image](https://cloud.githubusercontent.com/assets/572096/24070096/a0885a5c-0bf9-11e7-8847-a9d43dd7fedd.png)

As I known `1l` and `0l` are long 0000000000 and 1111111111

Thanks