### PR TITLE
Make Test SAPI compatible with 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   matrix:
     - PHPVER=7.0
     - PHPVER=7.1
+    - PHPVER=7.2
 
 matrix:
   include:

--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -4,4 +4,4 @@ set -e
 
 sudo add-apt-repository -y ppa:ondrej/php
 sudo apt-get -qq update
-sudo apt-get -qq install valgrind libgtest-dev libphp$PHPVER-embed php$PHPVER-dev
+sudo apt-get -qq install valgrind libgtest-dev libphp$PHPVER-embed php$PHPVER-dev libpcre3-dev

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ LIBRARY_CXX_SOURCES = \
 	phpcxx/superglobal.cpp \
 	phpcxx/value.cpp \
 	phpcxx/variables.cpp
-	
+
 LIBRARY_GCH = .build/phpcxx/precompiled.h.gch
 LIBRARY_PCH = phpcxx/precompiled.h
 

--- a/php-cxx-test.sup
+++ b/php-cxx-test.sup
@@ -72,3 +72,10 @@
    fun:zm_startup_core
 }
 
+{
+   _dlerror_run
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_dlerror_run
+}

--- a/test/test_callable.cpp
+++ b/test/test_callable.cpp
@@ -21,7 +21,6 @@ TEST(Callable, TestConstruct)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([] {
             runPhpCode(R"___(
@@ -75,7 +74,6 @@ TEST(Callable, TestResolve)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([] {
             zend_fcall_info fci;

--- a/test/test_constants.cpp
+++ b/test/test_constants.cpp
@@ -82,56 +82,53 @@ TEST(Constants, TestConstants)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
-        std::string o = out.str(); out.str("");
-        std::string e = err.str(); err.str("");
-        EXPECT_NE(std::string::npos, e.find("Constant STRING_CONST already defined"));
-        EXPECT_EQ("", o);
+        sapi.run([&out, &err]() {
+            std::string o = out.str(); out.str("");
+            std::string e = err.str(); err.str("");
+            EXPECT_NE(std::string::npos, e.find("Constant STRING_CONST already defined"));
+            EXPECT_EQ("", o);
 
-        zval* bc  = zend_get_constant_str(ZEND_STRL("BOOL_CONST"));
-        zval* ic  = zend_get_constant_str(ZEND_STRL("INT_CONST"));
-        zval* lc  = zend_get_constant_str(ZEND_STRL("LONG_CONST"));
-        zval* dc  = zend_get_constant_str(ZEND_STRL("DOUBLE_CONST"));
-        zval* fc  = zend_get_constant_str(ZEND_STRL("FLOAT_CONST"));
-        zval* nc  = zend_get_constant_str(ZEND_STRL("NULL_CONST"));
-        zval* sc1 = zend_get_constant_str(ZEND_STRL("STRING_CONST"));
-        zval* sc2 = zend_get_constant_str(ZEND_STRL("STRING_CONST2"));
-        zval* uc  = zend_get_constant_str(ZEND_STRL("NOT_USED_CONSTANT"));
+            zval* bc  = zend_get_constant_str(ZEND_STRL("BOOL_CONST"));
+            zval* ic  = zend_get_constant_str(ZEND_STRL("INT_CONST"));
+            zval* lc  = zend_get_constant_str(ZEND_STRL("LONG_CONST"));
+            zval* dc  = zend_get_constant_str(ZEND_STRL("DOUBLE_CONST"));
+            zval* fc  = zend_get_constant_str(ZEND_STRL("FLOAT_CONST"));
+            zval* nc  = zend_get_constant_str(ZEND_STRL("NULL_CONST"));
+            zval* sc1 = zend_get_constant_str(ZEND_STRL("STRING_CONST"));
+            zval* sc2 = zend_get_constant_str(ZEND_STRL("STRING_CONST2"));
+            zval* uc  = zend_get_constant_str(ZEND_STRL("NOT_USED_CONSTANT"));
 
-        ASSERT_TRUE(bc  != nullptr);
-        ASSERT_TRUE(ic  != nullptr);
-        ASSERT_TRUE(lc  != nullptr);
-        ASSERT_TRUE(dc  != nullptr);
-        ASSERT_TRUE(fc  != nullptr);
-        ASSERT_TRUE(nc  != nullptr);
-        ASSERT_TRUE(sc1 != nullptr);
-        ASSERT_TRUE(sc2 != nullptr);
-        EXPECT_EQ(uc, nullptr);
+            ASSERT_TRUE(bc  != nullptr);
+            ASSERT_TRUE(ic  != nullptr);
+            ASSERT_TRUE(lc  != nullptr);
+            ASSERT_TRUE(dc  != nullptr);
+            ASSERT_TRUE(fc  != nullptr);
+            ASSERT_TRUE(nc  != nullptr);
+            ASSERT_TRUE(sc1 != nullptr);
+            ASSERT_TRUE(sc2 != nullptr);
+            EXPECT_EQ(uc, nullptr);
 
-        EXPECT_EQ(IS_TRUE,   Z_TYPE_P(bc));
+            EXPECT_EQ(IS_TRUE,   Z_TYPE_P(bc));
 
-        EXPECT_EQ(IS_LONG,   Z_TYPE_P(ic));
-        EXPECT_EQ(IS_LONG,   Z_TYPE_P(lc));
-        EXPECT_EQ(10,        Z_LVAL_P(ic));
-        EXPECT_EQ(100,       Z_LVAL_P(lc));
+            EXPECT_EQ(IS_LONG,   Z_TYPE_P(ic));
+            EXPECT_EQ(IS_LONG,   Z_TYPE_P(lc));
+            EXPECT_EQ(10,        Z_LVAL_P(ic));
+            EXPECT_EQ(100,       Z_LVAL_P(lc));
 
-        EXPECT_EQ(IS_DOUBLE, Z_TYPE_P(dc));
-        EXPECT_EQ(IS_DOUBLE, Z_TYPE_P(fc));
-        EXPECT_EQ(200,       Z_DVAL_P(dc));
-        EXPECT_EQ(300,       Z_DVAL_P(fc));
+            EXPECT_EQ(IS_DOUBLE, Z_TYPE_P(dc));
+            EXPECT_EQ(IS_DOUBLE, Z_TYPE_P(fc));
+            EXPECT_EQ(200,       Z_DVAL_P(dc));
+            EXPECT_EQ(300,       Z_DVAL_P(fc));
 
-        EXPECT_EQ(IS_NULL,   Z_TYPE_P(nc));
+            EXPECT_EQ(IS_NULL,   Z_TYPE_P(nc));
 
-        ASSERT_EQ(IS_STRING, Z_TYPE_P(sc1));
-        ASSERT_EQ(IS_STRING, Z_TYPE_P(sc2));
+            ASSERT_EQ(IS_STRING, Z_TYPE_P(sc1));
+            ASSERT_EQ(IS_STRING, Z_TYPE_P(sc2));
 
-        EXPECT_STREQ("string",      Z_STRVAL_P(sc1));
-        EXPECT_STREQ("std::string", Z_STRVAL_P(sc2));
-
-        // Issue #4: if we don't run php_request_startup() and php_request_shutdown() after sapi.initialize()
-        // we can get memory corruption in NTS builds
-        sapi.run();
+            EXPECT_STREQ("string",      Z_STRVAL_P(sc1));
+            EXPECT_STREQ("std::string", Z_STRVAL_P(sc2));
+        });
     }
 
     std::string o = out.str(); out.str("");
@@ -150,59 +147,56 @@ TEST(Constants, TestManualRegistration)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
-        phpcxx::Constant false_const("FALSE_CONST", false);
-        EXPECT_FALSE(false_const.registerConstant());
+        sapi.run([&out, &err]() {
+            phpcxx::Constant false_const("FALSE_CONST", false);
+            EXPECT_FALSE(false_const.registerConstant());
 
-        std::string o = out.str(); out.str("");
-        std::string e = err.str(); err.str("");
-        EXPECT_NE(std::string::npos, e.find("Constant STRING_CONST already defined"));
-        EXPECT_EQ("", o);
+            std::string o = out.str(); out.str("");
+            std::string e = err.str(); err.str("");
+            EXPECT_NE(std::string::npos, e.find("Constant STRING_CONST already defined"));
+            EXPECT_EQ("", o);
 
-        zval* bc  = zend_get_constant_str(ZEND_STRL("BOOL_CONST"));
-        zval* ic  = zend_get_constant_str(ZEND_STRL("INT_CONST"));
-        zval* lc  = zend_get_constant_str(ZEND_STRL("LONG_CONST"));
-        zval* dc  = zend_get_constant_str(ZEND_STRL("DOUBLE_CONST"));
-        zval* fc  = zend_get_constant_str(ZEND_STRL("FLOAT_CONST"));
-        zval* nc  = zend_get_constant_str(ZEND_STRL("NULL_CONST"));
-        zval* sc1 = zend_get_constant_str(ZEND_STRL("STRING_CONST"));
-        zval* sc2 = zend_get_constant_str(ZEND_STRL("STRING_CONST2"));
-        zval* uc  = zend_get_constant_str(ZEND_STRL("NOT_USED_CONSTANT"));
+            zval* bc  = zend_get_constant_str(ZEND_STRL("BOOL_CONST"));
+            zval* ic  = zend_get_constant_str(ZEND_STRL("INT_CONST"));
+            zval* lc  = zend_get_constant_str(ZEND_STRL("LONG_CONST"));
+            zval* dc  = zend_get_constant_str(ZEND_STRL("DOUBLE_CONST"));
+            zval* fc  = zend_get_constant_str(ZEND_STRL("FLOAT_CONST"));
+            zval* nc  = zend_get_constant_str(ZEND_STRL("NULL_CONST"));
+            zval* sc1 = zend_get_constant_str(ZEND_STRL("STRING_CONST"));
+            zval* sc2 = zend_get_constant_str(ZEND_STRL("STRING_CONST2"));
+            zval* uc  = zend_get_constant_str(ZEND_STRL("NOT_USED_CONSTANT"));
 
-        ASSERT_TRUE(bc  != nullptr);
-        ASSERT_TRUE(ic  != nullptr);
-        ASSERT_TRUE(lc  != nullptr);
-        ASSERT_TRUE(dc  != nullptr);
-        ASSERT_TRUE(fc  != nullptr);
-        ASSERT_TRUE(nc  != nullptr);
-        ASSERT_TRUE(sc1 != nullptr);
-        ASSERT_TRUE(sc2 != nullptr);
-        EXPECT_EQ(uc, nullptr);
+            ASSERT_TRUE(bc  != nullptr);
+            ASSERT_TRUE(ic  != nullptr);
+            ASSERT_TRUE(lc  != nullptr);
+            ASSERT_TRUE(dc  != nullptr);
+            ASSERT_TRUE(fc  != nullptr);
+            ASSERT_TRUE(nc  != nullptr);
+            ASSERT_TRUE(sc1 != nullptr);
+            ASSERT_TRUE(sc2 != nullptr);
+            EXPECT_EQ(uc, nullptr);
 
-        EXPECT_EQ(IS_TRUE,   Z_TYPE_P(bc));
+            EXPECT_EQ(IS_TRUE,   Z_TYPE_P(bc));
 
-        EXPECT_EQ(IS_LONG,   Z_TYPE_P(ic));
-        EXPECT_EQ(IS_LONG,   Z_TYPE_P(lc));
-        EXPECT_EQ(10,        Z_LVAL_P(ic));
-        EXPECT_EQ(100,       Z_LVAL_P(lc));
+            EXPECT_EQ(IS_LONG,   Z_TYPE_P(ic));
+            EXPECT_EQ(IS_LONG,   Z_TYPE_P(lc));
+            EXPECT_EQ(10,        Z_LVAL_P(ic));
+            EXPECT_EQ(100,       Z_LVAL_P(lc));
 
-        EXPECT_EQ(IS_DOUBLE, Z_TYPE_P(dc));
-        EXPECT_EQ(IS_DOUBLE, Z_TYPE_P(fc));
-        EXPECT_EQ(200,       Z_DVAL_P(dc));
-        EXPECT_EQ(300,       Z_DVAL_P(fc));
+            EXPECT_EQ(IS_DOUBLE, Z_TYPE_P(dc));
+            EXPECT_EQ(IS_DOUBLE, Z_TYPE_P(fc));
+            EXPECT_EQ(200,       Z_DVAL_P(dc));
+            EXPECT_EQ(300,       Z_DVAL_P(fc));
 
-        EXPECT_EQ(IS_NULL,   Z_TYPE_P(nc));
+            EXPECT_EQ(IS_NULL,   Z_TYPE_P(nc));
 
-        ASSERT_EQ(IS_STRING, Z_TYPE_P(sc1));
-        ASSERT_EQ(IS_STRING, Z_TYPE_P(sc2));
+            ASSERT_EQ(IS_STRING, Z_TYPE_P(sc1));
+            ASSERT_EQ(IS_STRING, Z_TYPE_P(sc2));
 
-        EXPECT_STREQ("string",      Z_STRVAL_P(sc1));
-        EXPECT_STREQ("std::string", Z_STRVAL_P(sc2));
-
-        // Issue #4: if we don't run php_request_startup() and php_request_shutdown() after sapi.initialize()
-        // we can get memory corruption in NTS builds
-        sapi.run();
+            EXPECT_STREQ("string",      Z_STRVAL_P(sc1));
+            EXPECT_STREQ("std::string", Z_STRVAL_P(sc2));
+        });
     }
 
     std::string o = out.str(); out.str("");

--- a/test/test_fcall.cpp
+++ b/test/test_fcall.cpp
@@ -51,7 +51,6 @@ TEST(FCall, TestExceptions)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([]() {
             zval undef;
@@ -105,7 +104,6 @@ TEST(FCall, TestBailout)
     std::string e;
     TestSAPI sapi(out, err);
     sapi.addModule(module);
-    sapi.initialize();
 
     {
         bool bailed_out = false;
@@ -171,7 +169,6 @@ TEST(FCall, TestNormalCall)
     std::string e;
     TestSAPI sapi(out, err);
     sapi.addModule(module);
-    sapi.initialize();
 
     {
         bool bailed_out = false;

--- a/test/test_functions.cpp
+++ b/test/test_functions.cpp
@@ -210,7 +210,6 @@ TEST(FunctionsTest, Definitions)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([&out, &err, &o, &e]() {
             zval res;
@@ -398,7 +397,6 @@ TEST(FunctionsTest, SimpleCalls)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         std::string o;
         std::string e;
@@ -477,7 +475,6 @@ TEST(FunctionsTest, ParamsByReference)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         std::string o;
         std::string e;

--- a/test/test_hotp.cpp
+++ b/test/test_hotp.cpp
@@ -114,7 +114,6 @@ TEST(HOTP, TestHOTP)
         MyModule ext("HOTP", nullptr);
         TestSAPI sapi(out, err);
         sapi.addModule(ext);
-        sapi.initialize();
 
         sapi.run([]() {
             runPhpCode("echo HOTP::generateByCounter(1, '12345678901234567890'), \"\n\";");

--- a/test/test_lifecycle.cpp
+++ b/test/test_lifecycle.cpp
@@ -108,23 +108,12 @@ TEST(LifecycleTest, NormalRequest)
         TestSAPI sapi(std::cout, std::cerr);
         sapi.addModule(ext);
 
-        sapi.initialize();
-        EXPECT_EQ(1, ext.module_startup_called);
-        EXPECT_EQ(0, ext.module_shutdown_called);
-        EXPECT_EQ(0, ext.request_startup_called);
-        EXPECT_EQ(0, ext.request_shutdown_called);
-
         sapi.run([&ext]() {
             EXPECT_EQ(1, ext.module_startup_called);
             EXPECT_EQ(0, ext.module_shutdown_called);
             EXPECT_EQ(1, ext.request_startup_called);
             EXPECT_EQ(0, ext.request_shutdown_called);
         });
-
-        EXPECT_EQ(1, ext.module_startup_called);
-        EXPECT_EQ(0, ext.module_shutdown_called);
-        EXPECT_EQ(1, ext.request_startup_called);
-        EXPECT_EQ(1, ext.request_shutdown_called);
     }
 
     EXPECT_EQ(1, ext.module_startup_called);
@@ -149,12 +138,6 @@ TEST(LifecycleTest, ErroredRequest)
         TestSAPI sapi(out, err);
         sapi.addModule(ext);
 
-        sapi.initialize();
-        EXPECT_EQ(1, ext.module_startup_called);
-        EXPECT_EQ(0, ext.module_shutdown_called);
-        EXPECT_EQ(0, ext.request_startup_called);
-        EXPECT_EQ(0, ext.request_shutdown_called);
-
         sapi.run([&ext]() {
             EXPECT_EQ(1, ext.module_startup_called);
             EXPECT_EQ(0, ext.module_shutdown_called);
@@ -163,11 +146,6 @@ TEST(LifecycleTest, ErroredRequest)
 
             zend_error(E_ERROR, "Very fatal error");
         });
-
-        EXPECT_EQ(1, ext.module_startup_called);
-        EXPECT_EQ(0, ext.module_shutdown_called);
-        EXPECT_EQ(1, ext.request_startup_called);
-        EXPECT_EQ(1, ext.request_shutdown_called);
 
         EXPECT_EQ(out.str(), "");
         std::string errors = err.str();
@@ -194,12 +172,6 @@ TEST(LifecycleTest, MultipleRequests)
         TestSAPI sapi(std::cout, std::cerr);
         sapi.addModule(ext);
 
-        sapi.initialize();
-        EXPECT_EQ(1, ext.module_startup_called);
-        EXPECT_EQ(0, ext.module_shutdown_called);
-        EXPECT_EQ(0, ext.request_startup_called);
-        EXPECT_EQ(0, ext.request_shutdown_called);
-
         for (int i=0; i<n; ++i) {
             sapi.run([&ext, &i]() {
                 EXPECT_EQ(1,   ext.module_startup_called);
@@ -208,11 +180,6 @@ TEST(LifecycleTest, MultipleRequests)
                 EXPECT_EQ(i,   ext.request_shutdown_called);
             });
         }
-
-        EXPECT_EQ(1, ext.module_startup_called);
-        EXPECT_EQ(0, ext.module_shutdown_called);
-        EXPECT_EQ(n, ext.request_startup_called);
-        EXPECT_EQ(n, ext.request_shutdown_called);
     }
 
     EXPECT_EQ(1, ext.module_startup_called);
@@ -230,10 +197,6 @@ TEST(LifecycleTest, AdditionalModule)
         {
             TestSAPI sapi(std::cout, std::cerr);
             sapi.addModule(ext1);
-
-            sapi.initialize();
-            EXPECT_EQ(1, ext1.module_startup_called);
-            EXPECT_EQ(1, ext2.module_startup_called);
 
             sapi.run([&ext1, &ext2]() {
                 EXPECT_EQ(1, ext1.request_startup_called);
@@ -254,12 +217,10 @@ TEST(LifecycleTest, AdditionalModule)
             TestSAPI sapi(std::cout, std::cerr);
             sapi.addModule(ext1);
 
-            sapi.initialize();
-            zend_startup_module(ext2.module());
-            EXPECT_EQ(1, ext1.module_startup_called);
-            EXPECT_EQ(1, ext2.module_startup_called);
-
             sapi.run([&ext1, &ext2]() {
+                zend_startup_module(ext2.module());
+                EXPECT_EQ(1, ext1.module_startup_called);
+                EXPECT_EQ(1, ext2.module_startup_called);
                 EXPECT_EQ(1, ext1.request_startup_called);
                 // When a module is loaded after MINIT phase,
                 // its request startup / shutdown functions

--- a/test/test_moduleglobals.cpp
+++ b/test/test_moduleglobals.cpp
@@ -67,14 +67,13 @@ TEST(ModuleGlobalsTest, TestModuleGlobals)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
-        std::string o = out.str(); out.str("");
-        std::string e = err.str(); err.str("");
-        EXPECT_EQ("", e);
-        EXPECT_EQ("globalsConstructor\nmoduleStartup\n", o);
+        sapi.run([&module, &out, &err]() {
+            std::string o = out.str(); out.str("");
+            std::string e = err.str(); err.str("");
+            EXPECT_EQ("", e);
+            EXPECT_EQ("globalsConstructor\nmoduleStartup\n", o);
 
-        sapi.run([&module]() {
             MyModuleGlobals* g1 = static_cast<MyModuleGlobals*>(module.globals());
             MyModuleGlobals* g2 = dynamic_cast<MyModuleGlobals*>(module.globals());
             ASSERT_TRUE(g1 != nullptr);

--- a/test/test_parameters.cpp
+++ b/test/test_parameters.cpp
@@ -77,7 +77,6 @@ TEST(Parameters, TestCoercion)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([]() {
             runPhpCode(R"___(
@@ -134,7 +133,6 @@ TEST(Parameters, TestVerify)
         MyModule module("Parameters", "0.0");
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([&err]() {
             DummyStackFrame dummy;
@@ -187,7 +185,6 @@ set_error_handler("exception_error_handler");
         MyModule module("Parameters", "0.0");
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([]() {
             DummyStackFrame dummy;
@@ -212,7 +209,6 @@ TEST(Parameters, TestInitialization)
         MyModule module("Parameters", "0.0");
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([]() {
             phpcxx::Value v1 = true;

--- a/test/test_phpexception.cpp
+++ b/test/test_phpexception.cpp
@@ -195,7 +195,6 @@ TEST(PhpException, TestSimpleException)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([&err] {
             runPhpCode(R"___(
@@ -228,7 +227,6 @@ TEST(PhpException, TestNestedException)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([&err] {
             runPhpCode(R"___(
@@ -266,7 +264,6 @@ TEST(PhpException, TestInvalidArguments)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([&err] {
             ASSERT_EQ(nullptr, EG(exception));
@@ -297,7 +294,6 @@ TEST(PhpException, TestIssue23)
         MyModule module("PhpException", "0.0");
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([&success] {
             DummyStackFrame dummy;
@@ -325,7 +321,6 @@ TEST(PhpException, TestIssue23)
         MyModule module("PhpException", "0.0");
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([&success] {
             DummyStackFrame dummy;
@@ -353,7 +348,6 @@ TEST(PhpException, TestIssue23)
         MyModule module("PhpException", "0.0");
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([&success] {
             DummyStackFrame dummy;
@@ -381,7 +375,6 @@ TEST(PhpException, TestIssue23)
         MyModule module("PhpException", "0.0");
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([&success] {
             DummyStackFrame dummy;

--- a/test/test_superglobals.cpp
+++ b/test/test_superglobals.cpp
@@ -59,7 +59,6 @@ TEST(SuperGlobals, testBasic)
         MyModule ext("SuperGlobals", nullptr);
         TestSAPI sapi(out, err);
         sapi.addModule(ext);
-        sapi.initialize();
 
         sapi.run([]() {
             zval r;
@@ -85,7 +84,6 @@ TEST(SuperGlobals, testBasic)
         MyModule ext("SuperGlobals", nullptr);
         TestSAPI sapi(out, err);
         sapi.addModule(ext);
-        sapi.initialize();
 
         sapi.run([]() {
             char sg_int[] = "SUPERGLOBAL_INT";
@@ -111,7 +109,6 @@ TEST(SuperGlobals, testBasic)
         MyModule ext("SuperGlobals", nullptr);
         TestSAPI sapi(out, err);
         sapi.addModule(ext);
-        sapi.initialize();
 
         sapi.run([]() {
             zval r;
@@ -173,7 +170,6 @@ TEST(SuperGlobals, testOperations)
         MyModule ext("SuperGlobals", nullptr);
         TestSAPI sapi(out, err);
         sapi.addModule(ext);
-        sapi.initialize();
 
         sapi.run([]() {
             phpcxx::ZendString za("a");

--- a/test/test_zendstring.cpp
+++ b/test/test_zendstring.cpp
@@ -20,7 +20,6 @@ TEST(ZendString, TestConstruct)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([] {
             phpcxx::ZendString zs1("c string");
@@ -78,7 +77,6 @@ TEST(ZendString, TestAssign)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([] {
 #if PHP_VERSION_ID < 70200
@@ -150,7 +148,6 @@ TEST(ZendString, TestReferences)
     {
         TestSAPI sapi(out, err);
         sapi.addModule(module);
-        sapi.initialize();
 
         sapi.run([] {
 #if PHP_VERSION_ID < 70200

--- a/test/testsapi.cpp
+++ b/test/testsapi.cpp
@@ -1,6 +1,7 @@
 #include <cstring>
 #include <vector>
 #include "phpcxx/module.h"
+#include "phpcxx/zendstring.h"
 #include "testsapi.h"
 
 extern "C" {
@@ -9,35 +10,48 @@ extern "C" {
 #include <main/SAPI.h>
 #include <main/php_variables.h>
 #include <Zend/zend_exceptions.h>
+#include <Zend/zend_ini.h>
+#include <Zend/zend_string.h>
+#include <sapi/embed/php_embed.h>
 }
 
 namespace {
 
-static const char hardcoded_ini[] =
-    "html_errors=0\n"
-    "log_errors=1\n"
-    "display_errors=0\n"
-    "error_reporting=E_ALL\n"
-    "report_zend_debug=0\n"
-    "register_argc_argv=1\n"
-    "implicit_flush=1\n"
-    "output_buffering=0\n"
-    "max_execution_time=0\n"
-    "extension_dir=\n"
-    "max_input_time=-1\n\0"
-;
+static PHP_MINIT_FUNCTION(fake)
+{
+    PG(log_errors)        = 1;
+    PG(display_errors)    = 0;
+    EG(error_reporting)   = E_ALL;
+    PG(report_zend_debug) = 0;
+    return SUCCESS;
+}
 
-static int sapi_startup(sapi_module_struct* sapi_module);
-static int sapi_activate();
-static int sapi_deactivate();
-static size_t sapi_ub_write(const char* str, size_t str_length);
-static void sapi_flush(void*);
-static void sapi_send_header(sapi_header_struct*, void*);
-static char* sapi_read_cookies();
+static zend_module_entry fake_module = {
+    STANDARD_MODULE_HEADER_EX,
+    nullptr,    // INI
+    nullptr,    // deps
+    const_cast<char*>("fake"),    // extname
+    nullptr,    // functions,
+    PHP_MINIT(fake),
+    nullptr,    // MSHUTDOWN
+    nullptr,    // RINIT
+    nullptr,    // RSHUTDOWN
+    nullptr,    // MINFO
+    NO_VERSION_YET,
+    STANDARD_MODULE_PROPERTIES
+};
+
+static int my_sapi_startup(sapi_module_struct* sapi_module);
+static int my_sapi_activate();
+static int my_sapi_deactivate();
+static size_t my_sapi_ub_write(const char* str, size_t str_length);
+static void my_sapi_flush(void*);
+static void my_sapi_send_header(sapi_header_struct*, void*);
+static char* my_sapi_read_cookies();
 #if PHP_VERSION_ID >= 70100
-static void sapi_log_message(char* message, int syslog_type_int);
+static void my_sapi_log_message(char* message, int syslog_type_int);
 #else
-static void sapi_log_message(char* message);
+static void my_sapi_log_message(char* message);
 #endif
 
 class SAPIGlobals {
@@ -46,53 +60,6 @@ public:
     std::ostream* err;
     std::vector<zend_module_entry> mods;
 
-    sapi_module_struct sapi = {
-        const_cast<char*>("test"),          // name
-        const_cast<char*>("Test SAPI"),     // pretty_name
-        sapi_startup,                       // startup
-        php_module_shutdown_wrapper,        // shutdown
-        sapi_activate,                      // activate
-        sapi_deactivate,                    // deactivate
-        sapi_ub_write,                      // ub_write
-        sapi_flush,                         // flush
-#if PHP_VERSION_ID >= 70100
-        nullptr,                            // get_stat
-#else
-        nullptr,                            // get UID
-#endif
-        nullptr,                            // getenv
-        zend_error,                         // sapi_error
-        nullptr,                            // header_handler
-        nullptr,                            // send_headers
-        sapi_send_header,                   // send_header
-        nullptr,                            // read_post
-        sapi_read_cookies,                  // read_cookies
-        php_import_environment_variables,   // register_server_variables
-        sapi_log_message,                   // log_message
-        nullptr,                            // double (*get_request_time)(void);
-        nullptr,                            // void (*terminate_process)(void);
-        nullptr,                            // char *php_ini_path_override;
-#if PHP_VERSION_ID < 70100
-        nullptr,                            // void (*block_interruptions)(void);
-        nullptr,                            // void (*unblock_interruptions)(void);
-#endif
-        nullptr,    // void (*default_post_reader)(void);
-        nullptr,    // void (*treat_data)(int arg, char *str, zval *destArray);
-        const_cast<char*>("-"), // char *executable_location;
-        1,          // php_ini_ignore
-        1,          // php_ini_ignore_cwd
-        nullptr,    // int (*get_fd)(int *fd);
-        nullptr,    // int (*force_http_10)(void);
-        nullptr,    // int (*get_target_uid)(uid_t *);
-        nullptr,    // int (*get_target_gid)(gid_t *);
-        nullptr,    // unsigned int (*input_filter)(int arg, char *var, char **val, size_t val_len, size_t *new_val_len);
-        nullptr,    // void (*ini_defaults)(HashTable *configuration_hash);
-        1,          // phpinfo_as_text
-        nullptr,    // ini
-        nullptr,    // const zend_function_entry *additional_functions
-        nullptr     // unsigned int (*input_filter_init)(void)
-    };
-
     static SAPIGlobals& instance()
     {
         static SAPIGlobals self;
@@ -100,108 +67,94 @@ public:
     }
 
 private:
-    SAPIGlobals() : out(nullptr), err(nullptr) {}
+    SAPIGlobals() : out(nullptr), err(nullptr)
+    {
+        php_embed_module.startup      = my_sapi_startup;
+        php_embed_module.activate     = my_sapi_activate;
+        php_embed_module.deactivate   = my_sapi_deactivate;
+        php_embed_module.ub_write     = my_sapi_ub_write;
+        php_embed_module.flush        = my_sapi_flush;
+        php_embed_module.send_header  = my_sapi_send_header;
+        php_embed_module.read_cookies = my_sapi_read_cookies;
+        php_embed_module.log_message  = my_sapi_log_message;
+
+        mods.push_back(fake_module);
+    }
 };
 
-static int sapi_startup(sapi_module_struct* sapi_module)
+static int my_sapi_startup(sapi_module_struct* sapi_module)
 {
     SAPIGlobals& g = SAPIGlobals::instance();
     return php_module_startup(sapi_module, g.mods.data(), static_cast<uint>(g.mods.size()));
 }
 
-static int sapi_activate()
+static int my_sapi_activate()
 {
     return SUCCESS;
 }
 
-static int sapi_deactivate()
+static int my_sapi_deactivate()
 {
-    sapi_flush(nullptr);
+    my_sapi_flush(nullptr);
     return SUCCESS;
 }
 
-static size_t sapi_ub_write(const char* str, size_t str_length)
+static size_t my_sapi_ub_write(const char* str, size_t str_length)
 {
     SAPIGlobals::instance().out->write(str, static_cast<std::streamsize>(str_length)).flush();
     return str_length;
 }
 
-static void sapi_flush(void*)
+static void my_sapi_flush(void*)
 {
     SAPIGlobals::instance().out->flush();
 }
 
-static void sapi_send_header(sapi_header_struct*, void*)
+static void my_sapi_send_header(sapi_header_struct*, void*)
 {
 }
 
-static char* sapi_read_cookies()
+static char* my_sapi_read_cookies()
 {
     return nullptr;
 }
 
 #if PHP_VERSION_ID >= 70100
-static void sapi_log_message(char* message, int syslog_type_int)
+static void my_sapi_log_message(char* message, int syslog_type_int)
 {
     *(SAPIGlobals::instance().err) << message << std::endl;
 }
 #else
-static void sapi_log_message(char* message)
+static void my_sapi_log_message(char* message)
 {
     *(SAPIGlobals::instance().err) << message << std::endl;
 }
 #endif
-}
+
+} // namespace
 
 TestSAPI::TestSAPI(std::ostream& out, std::ostream& err)
-    : m_initialized(false)
+    : m_initialized(false), m_in_request(false)
 {
-#ifdef ZTS
-    tsrm_startup(1, 1, 0, NULL);
-    ts_resource(0);
-    ZEND_TSRMLS_CACHE_UPDATE();
-#endif
-
-#if defined(ZEND_SIGNALS)
-    zend_signal_startup();
-#endif
-
     SAPIGlobals& g = SAPIGlobals::instance();
     g.out = &out;
     g.err = &err;
-
-    ::sapi_startup(&g.sapi);
 }
 
 TestSAPI::~TestSAPI()
 {
-    php_module_shutdown();
-    ::sapi_shutdown();
+    if (this->m_initialized) {
+        if (!this->m_in_request) {
+            // php_embed_shutdown() calls php_request_shutdown(), we need to start a request
+            php_request_startup();
+        }
+
+        php_embed_shutdown();
+    }
 
     SAPIGlobals& g = SAPIGlobals::instance();
     g.mods.clear();
-
-#ifdef ZTS
-    tsrm_shutdown();
-#endif
-
-    if (g.sapi.ini_entries) {
-        delete[] g.sapi.ini_entries;
-        g.sapi.ini_entries = nullptr;
-    }
-}
-
-void TestSAPI::initialize()
-{
-    if (!this->m_initialized) {
-        SAPIGlobals& g = SAPIGlobals::instance();
-
-        g.sapi.ini_entries = new char[sizeof(hardcoded_ini)];
-        std::memcpy(g.sapi.ini_entries, hardcoded_ini, sizeof(hardcoded_ini));
-
-        g.sapi.startup(&g.sapi);
-        this->m_initialized = true;
-    }
+    g.mods.push_back(fake_module);
 }
 
 void TestSAPI::addModule(phpcxx::Module& ext)
@@ -212,24 +165,21 @@ void TestSAPI::addModule(phpcxx::Module& ext)
     }
 }
 
-void TestSAPI::run()
-{
-    this->initialize();
-
-    SG(options) |= SAPI_OPTION_NO_CHDIR;
-    php_request_startup();
-    php_request_shutdown(nullptr);
-}
-
 void TestSAPI::run(std::function<void(void)> callback)
 {
-    this->initialize();
+    if (!this->m_initialized) {
+        php_embed_init(0, nullptr);
+        this->m_initialized = true;
+    }
+    else {
+        if (this->m_in_request) {
+            php_request_shutdown(nullptr);
+        }
 
-    SG(options) |= SAPI_OPTION_NO_CHDIR;
-    php_request_startup();
-    SG(headers_sent) = 1;
-    SG(request_info).no_headers = 1;
-    php_register_variable(const_cast<char*>("PHP_SELF"), const_cast<char*>("-"), NULL);
+        php_request_startup();
+    }
+
+    this->m_in_request = true;
 
     zend_first_try {
         callback();
@@ -253,7 +203,7 @@ void TestSAPI::run(std::function<void(void)> callback)
         }
     }
 
-    php_request_shutdown(nullptr);
+//    php_request_shutdown(nullptr);
 }
 
 void TestSAPI::setOutputStream(std::ostream* os)

--- a/test/testsapi.h
+++ b/test/testsapi.h
@@ -13,15 +13,14 @@ public:
     TestSAPI(std::ostream& out, std::ostream& err);
     ~TestSAPI();
 
-    void initialize();
     void addModule(phpcxx::Module& ext);
-    void run();
     void run(std::function<void(void)> callback);
 
     [[gnu::nonnull]] void setOutputStream(std::ostream* os);
     [[gnu::nonnull]] void setErrorStream(std::ostream* os);
 private:
     bool m_initialized;
+    bool m_in_request;
 };
 
 #endif /* SAPI_H_ */


### PR DESCRIPTION
The tester is now based on the official Embed SAPI, as since 7.1.0 ZTS RELEASE versions are buggy (see https://bugs.php.net/bug.php?id=75735) and need to be built with --disable-zend-signals (see https://bugs.php.net/bug.php?id=71041).

Because PHP folks do their best to force everyone to use their SAPIs and not write one's owns, TestSAPI had to be rewritten on top of the Embed SAPI.
